### PR TITLE
Priorities for players

### DIFF
--- a/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
+++ b/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
@@ -134,7 +134,7 @@
 				TargetAttributes = {
 					336F74471E07E136009BCC1B = {
 						CreatedOnToolsVersion = 8.2;
-						DevelopmentTeam = 99QSH5L9VP;
+						DevelopmentTeam = KAX983KY52;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {

--- a/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
+++ b/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
@@ -134,7 +134,7 @@
 				TargetAttributes = {
 					336F74471E07E136009BCC1B = {
 						CreatedOnToolsVersion = 8.2;
-						DevelopmentTeam = KAX983KY52;
+						DevelopmentTeam = 99QSH5L9VP;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
@@ -242,7 +242,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -283,7 +283,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 			};
@@ -297,10 +297,10 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = KAX983KY52;
+				DEVELOPMENT_TEAM = 99QSH5L9VP;
 				INFOPLIST_FILE = HighSierraMediaKeyEnabler/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.milgra.hsmke;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -315,10 +315,10 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = KAX983KY52;
+				DEVELOPMENT_TEAM = 99QSH5L9VP;
 				INFOPLIST_FILE = HighSierraMediaKeyEnabler/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.milgra.hsmke;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/HighSierraMediaKeyEnabler/AppDelegate.h
+++ b/HighSierraMediaKeyEnabler/AppDelegate.h
@@ -4,7 +4,13 @@
     #import "iTunes.h"
     #import "Spotify.h"
 
-    @interface AppDelegate : NSObject <NSApplicationDelegate>
+    typedef NS_ENUM(NSInteger, MediaKeysPrioritize) {
+        MediaKeysPrioritizeNone,    // Normal behavior (without priority; send events to iTunes and Spotify if both are open)
+        MediaKeysPrioritizeITunes,  // If both apps are open, prioritize iTunes over Spotify
+        MediaKeysPrioritizeSpotify  // If both apps are open, prioritize Spotify over iTunes
+    };
 
+    @interface AppDelegate : NSObject <NSApplicationDelegate>
+        @property (assign, nonatomic, readonly) MediaKeysPrioritize mediaKeysPriority;
     @end
 

--- a/HighSierraMediaKeyEnabler/Info.plist
+++ b/HighSierraMediaKeyEnabler/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.5</string>
 	<key>CFBundleVersion</key>
-	<string>1.4</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Added some menu options to prioritize one player over another if both are open.

For example if you leave iTunes opened to allow wireless sync to iPhones, but Spotify is your main player, you probably don't want both players to receive events, just Spotify.

So this adds 3 options:
- **Send events to both players**: This is the default (original) behavior.
- **Prioritize iTunes**: Send events only to iTunes if both players are opened (default behavior if only one is opened).
- **Prioritize Spotify**: Same as above, but events will be sent only to Spotify if iTunes is also opened.