### PR TITLE
Scrubbing support for iTunes

### DIFF
--- a/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
+++ b/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		33CD48BF1F866DB7000C454F /* ScriptingBridge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CD48BE1F866DB7000C454F /* ScriptingBridge.framework */; };
 		33CD48CB1F867394000C454F /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 33CD48C71F8671B6000C454F /* icon.png */; };
 		33CD48CC1F867408000C454F /* icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 33CD48C91F86724F000C454F /* icon@2x.png */; };
+		A5999C4C1FF3BB89009905E1 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A5999C4E1FF3BB89009905E1 /* Localizable.strings */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +36,8 @@
 		33CD48C11F866DC6000C454F /* iTunes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iTunes.h; sourceTree = "<group>"; };
 		33CD48C71F8671B6000C454F /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
 		33CD48C91F86724F000C454F /* icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon@2x.png"; sourceTree = "<group>"; };
+		A5999C4D1FF3BB89009905E1 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		A5999C4F1FF3BB98009905E1 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +94,7 @@
 				3319A9E81E085353005DB79C /* LICENSE */,
 				3319A9E91E085353005DB79C /* README.md */,
 				336F744F1E07E136009BCC1B /* main.m */,
+				A5999C4E1FF3BB89009905E1 /* Localizable.strings */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -151,6 +155,7 @@
 			knownRegions = (
 				en,
 				Base,
+				ko,
 			);
 			mainGroup = 336F743F1E07E136009BCC1B;
 			productRefGroup = 336F74491E07E136009BCC1B /* Products */;
@@ -168,6 +173,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				336F74521E07E136009BCC1B /* Assets.xcassets in Resources */,
+				A5999C4C1FF3BB89009905E1 /* Localizable.strings in Resources */,
 				33CD48CC1F867408000C454F /* icon@2x.png in Resources */,
 				336F74551E07E136009BCC1B /* MainMenu.xib in Resources */,
 				3319A9EA1E085353005DB79C /* LICENSE in Resources */,
@@ -198,6 +204,15 @@
 			name = MainMenu.xib;
 			sourceTree = "<group>";
 		};
+		A5999C4E1FF3BB89009905E1 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				A5999C4D1FF3BB89009905E1 /* en */,
+				A5999C4F1FF3BB98009905E1 /* ko */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
@@ -205,6 +220,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -252,6 +268,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -195,13 +195,13 @@
         [ menu addItemWithTitle : versionString action : nil keyEquivalent : @"" ];
         [ menu addItem : [ NSMenuItem separatorItem ] ]; // A thin grey line
         
-        [priorityItems addObject:[ menu addItemWithTitle: @"Send events to both players" action : @selector(prioritizeNone) keyEquivalent : @"" ]];
-        [priorityItems addObject:[ menu addItemWithTitle: @"Prioritize iTunes" action : @selector(prioritizeITunes) keyEquivalent : @"" ]];
-        [priorityItems addObject:[ menu addItemWithTitle: @"Prioritize Spotify" action : @selector(prioritizeSpotify) keyEquivalent : @"" ]];
+        [priorityItems addObject:[ menu addItemWithTitle: NSLocalizedString(@"Send events to both players", @"Send events to both players") action : @selector(prioritizeNone) keyEquivalent : @"" ]];
+        [priorityItems addObject:[ menu addItemWithTitle: NSLocalizedString(@"Prioritize iTunes", @"Prioritize iTunes") action : @selector(prioritizeITunes) keyEquivalent : @"" ]];
+        [priorityItems addObject:[ menu addItemWithTitle: NSLocalizedString(@"Prioritize Spotify", @"Prioritize Spotify") action : @selector(prioritizeSpotify) keyEquivalent : @"" ]];
         [ menu addItem : [ NSMenuItem separatorItem ] ]; // A thin grey line
-        [ menu addItemWithTitle : @"Donate if you like the app" action : @selector(support) keyEquivalent : @"" ];
-        [ menu addItemWithTitle : @"Check for updates" action : @selector(update) keyEquivalent : @"" ];
-        [ menu addItemWithTitle : @"Quit" action : @selector(terminate) keyEquivalent : @"" ];
+        [ menu addItemWithTitle : NSLocalizedString(@"Donate if you like the app", @"Donate if you like the app") action : @selector(support) keyEquivalent : @"" ];
+        [ menu addItemWithTitle : NSLocalizedString(@"Check for updates", @"Check for updates") action : @selector(update) keyEquivalent : @"" ];
+        [ menu addItemWithTitle : NSLocalizedString(@"Quit", @"Quit") action : @selector(terminate) keyEquivalent : @"" ];
         
         priorityOptionItems = [priorityItems copy];
         priorityItems = nil;

--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -4,6 +4,12 @@
     // NSUserDefaults key for the last user-chosen priority option
     static NSString *kUserDefaultsPriorityOptionKey = @"user_priority_option";
 
+    typedef NS_ENUM(NSInteger, KeyHoldState) {
+        KeyHoldStateNone,
+        KeyHoldStateWaiting,
+        KeyHoldStateHolding
+    };
+
     @interface AppDelegate ()
     {
         NSStatusItem* statusItem;
@@ -11,6 +17,8 @@
         CFRunLoopSourceRef eventPortSource;
         NSArray<NSMenuItem *> *priorityOptionItems;
     }
+
+    @property (nonatomic) KeyHoldState keyHoldStatus;
 
     @end
 
@@ -50,39 +58,51 @@
             
             int keyFlags = ([nsEvent data1] & 0x0000FFFF);
             BOOL keyIsPressed = (((keyFlags & 0xFF00) >> 8)) == 0xA;
-
+            
+            iTunesApplication *iTunes = [SBApplication applicationWithBundleIdentifier:@"com.apple.iTunes"];
+            SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
+            
             if (keyIsPressed)
             {
                 switch ( self.mediaKeysPriority ) {
                     case MediaKeysPrioritizeITunes:
                     {
-                        iTunesApplication* iTunes = [SBApplication applicationWithBundleIdentifier:@"com.apple.iTunes"];
                         switch (keyCode) {
                             // Play/pause
                             case NX_KEYTYPE_PLAY:[iTunes playpause];break;
-                            
-                            // Fast forward
-                            case NX_KEYTYPE_NEXT:
-                            case NX_KEYTYPE_FAST:[iTunes nextTrack];break;
-                                
-                            // Rewind
-                            case NX_KEYTYPE_PREVIOUS:
-                            case NX_KEYTYPE_REWIND:[iTunes backTrack];break;
+
+                            default:
+                            {
+                                if (self.keyHoldStatus == KeyHoldStateNone) self.keyHoldStatus = KeyHoldStateWaiting;
+                                else if (self.keyHoldStatus == KeyHoldStateWaiting)
+                                {
+                                    self.keyHoldStatus = KeyHoldStateHolding;
+                                    switch (keyCode) {
+                                        // Fast forward
+                                        case NX_KEYTYPE_NEXT:
+                                        case NX_KEYTYPE_FAST:[iTunes fastForward];break;
+                                        
+                                        // Rewind
+                                        case NX_KEYTYPE_PREVIOUS:
+                                        case NX_KEYTYPE_REWIND:[iTunes rewind];break;
+                                    }
+                                }
+                            }
                         }
                         break;
                     }
                     case MediaKeysPrioritizeSpotify:
                     {
-                        SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
+                        
                         switch (keyCode) {
                             // Play/pause
                             case NX_KEYTYPE_PLAY:[spotify playpause];break;
                             
-                            // Fast forward
+                            // Next track
                             case NX_KEYTYPE_NEXT:
                             case NX_KEYTYPE_FAST:[spotify nextTrack];break;
                                
-                            // Rewind
+                            // Previous track or go to start position of current track
                             case NX_KEYTYPE_PREVIOUS:
                             case NX_KEYTYPE_REWIND:[spotify previousTrack];break;
                         }
@@ -90,8 +110,6 @@
                     }
                     default:
                     {
-                        iTunesApplication* iTunes = [SBApplication applicationWithBundleIdentifier:@"com.apple.iTunes"];
-                        SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
                         // legacy behaviour
                         switch (keyCode) {
                             // Play/pause
@@ -102,7 +120,7 @@
                                 break;
                             }
                                
-                            // Fast forward
+                            // Next track
                             case NX_KEYTYPE_NEXT:
                             case NX_KEYTYPE_FAST:
                             {
@@ -111,7 +129,7 @@
                                 break;
                             }
                                
-                            // Rewind
+                            // Previous track or go to start position of current track
                             case NX_KEYTYPE_PREVIOUS:
                             case NX_KEYTYPE_REWIND:
                             {
@@ -124,6 +142,37 @@
                     }
                 }
             }
+            else
+            {
+                switch (self.keyHoldStatus)
+                {
+                    case KeyHoldStateWaiting:
+                    {
+                        if (self.mediaKeysPriority == MediaKeysPrioritizeITunes)
+                        {
+                            switch (keyCode) {
+                                // Next track
+                                case NX_KEYTYPE_NEXT:
+                                case NX_KEYTYPE_FAST:[iTunes nextTrack];break;
+                                    
+                                // Previous track or go to start position of current track
+                                case NX_KEYTYPE_PREVIOUS:
+                                case NX_KEYTYPE_REWIND:[iTunes backTrack];break;
+                            }
+                        }
+                        break;
+                    }
+                    case KeyHoldStateHolding:
+                    {
+                        // Stop fast forwarding / rewinding
+                        if (self.mediaKeysPriority == MediaKeysPrioritizeITunes) [iTunes resume];
+                        break;
+                    }
+                    default:break;
+                }
+                self.keyHoldStatus = KeyHoldStateNone;
+            }
+            
             // stop propagation
             return NULL;
         }
@@ -158,6 +207,8 @@
         priorityItems = nil;
         
         [self refreshItemTick]; // Update the "tick" for the selected option
+        
+        self.keyHoldStatus = KeyHoldStateNone; // Initialize the enum
         
         NSImage* image = [ NSImage imageNamed : @"icon" ];
         [ image setTemplate : YES ];

--- a/HighSierraMediaKeyEnabler/en.lproj/Localizable.strings
+++ b/HighSierraMediaKeyEnabler/en.lproj/Localizable.strings
@@ -1,0 +1,14 @@
+/* 
+  Localizable.strings
+  HighSierraMediaKeyEnabler
+
+  Created by Sungho Lee on 2017. 12. 27..
+  Copyright © 2017년 Milan Toth. All rights reserved.
+*/
+
+"Send events to both players" = "Send events to both players";
+"Prioritize iTunes" = "Prioritize iTunes";
+"Prioritize Spotify" = "Prioritize Spotify";
+"Donate if you like the app" = "Donate if you like the app";
+"Check for updates" = "Check for updates";
+"Quit" = "Quit";

--- a/HighSierraMediaKeyEnabler/ko.lproj/Localizable.strings
+++ b/HighSierraMediaKeyEnabler/ko.lproj/Localizable.strings
@@ -1,0 +1,14 @@
+/* 
+  Localizable.strings
+  HighSierraMediaKeyEnabler
+
+  Created by Sungho Lee on 2017. 12. 27..
+  Copyright © 2017년 Milan Toth. All rights reserved.
+*/
+
+"Send events to both players" = "모든 플레이어에 이벤트 보내기";
+"Prioritize iTunes" = "iTunes에 우선권 부여";
+"Prioritize Spotify" = "Spotify에 우선권 부여";
+"Donate if you like the app" = "이 앱이 마음에 들면 기부해주세요!";
+"Check for updates" = "업데이트 확인";
+"Quit" = "종료";

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you want even more control over what you want to control you should try [bear
 
 ---
 
-Contributors : Michael Dorner (michaeldorner), Matt Chaput (mchaput), Ben Kropf (ben-kropf), Alejandro Iván (alejandroivan), Sungho Lee (sh1217sh0)
+Contributors : Michael Dorner (michaeldorner), Matt Chaput (mchaput), Ben Kropf (ben-kropf), Alejandro Iván (alejandroivan), Sungho Lee (sh1217sh)
 
 Thank you!!!
 


### PR DESCRIPTION
This PR can be helpful for issue #2.
It only works when "Prioritize iTunes" option is selected.
I couldn't add Spotify support since Soptify.h doesn't provide scrubbing functions. Even worse, Spotify is not available in my country so I would not be able to test the app anyway.