### PR TITLE
German localization & check if Spotify/ iTunes is running

### DIFF
--- a/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
+++ b/HighSierraMediaKeyEnabler.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		112AF55920263497006937BF /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3319A9E81E085353005DB79C /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		3319A9E91E085353005DB79C /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		336F74481E07E136009BCC1B /* HighSierraMediaKeyEnabler.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HighSierraMediaKeyEnabler.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -134,7 +135,7 @@
 		336F74401E07E136009BCC1B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Milan Toth";
 				TargetAttributes = {
 					336F74471E07E136009BCC1B = {
@@ -156,6 +157,7 @@
 				en,
 				Base,
 				ko,
+				de,
 			);
 			mainGroup = 336F743F1E07E136009BCC1B;
 			productRefGroup = 336F74491E07E136009BCC1B /* Products */;
@@ -209,6 +211,7 @@
 			children = (
 				A5999C4D1FF3BB89009905E1 /* en */,
 				A5999C4F1FF3BB98009905E1 /* ko */,
+				112AF55920263497006937BF /* de */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -226,7 +229,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -234,7 +239,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -274,7 +283,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -282,7 +293,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;

--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -61,6 +61,11 @@
             
             iTunesApplication *iTunes = [SBApplication applicationWithBundleIdentifier:@"com.apple.iTunes"];
             SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
+        
+            //Use masOS 10.13 default behavior if neither iTunes nor Spotify is running
+            if (![spotify isRunning ] && ![iTunes isRunning ] ){
+                return event;
+            }
             
             if (keyIsPressed)
             {

--- a/HighSierraMediaKeyEnabler/Info.plist
+++ b/HighSierraMediaKeyEnabler/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/HighSierraMediaKeyEnabler/de.lproj/Localizable.strings
+++ b/HighSierraMediaKeyEnabler/de.lproj/Localizable.strings
@@ -1,0 +1,14 @@
+/* 
+  Localizable.strings
+  HighSierraMediaKeyEnabler
+
+  Created by maciboy on 2018. 02. 03..
+  Copyright © 2018년 Milan Toth. All rights reserved.
+*/
+
+"Send events to both players" = "Eingaben an geöffnete Player senden";
+"Prioritize iTunes" = "iTunes priorisieren";
+"Prioritize Spotify" = "Spotify priorisieren";
+"Donate if you like the app" = "Spenden";
+"Check for updates" = "Nach Updates suchen";
+"Quit" = "Beenden";

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Thank you!!!
 
 ---
 
+What's new in version 1.7 build 2:
+- Added check if iTunes or Spotify are running, if both are not running the new macOS default behavior is used and keys are forwarded to currently active media player
+- German localization
+
 What's new in version 1.7 :
 - fast forward/rewind is possible when iTunes is selected explicitly
 - Korean localization


### PR DESCRIPTION
Hey,
if you want you can have German localization for your tool @milgra 😄 

Also, I implemented a quick check to forward events to default macOS behavior if no supported player is running.
However, I don’t know if this behavior is desired by you or other users - I missed it as stated here https://github.com/milgra/highsierramediakeyenabler/issues/21

- Added check if Spotify or iTunes is running, if not use macOS 10.13 behavior and forward event to current media application
- Added german localization
- Updated readme accordingly