### PR TITLE
Performance improvements

### DIFF
--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -89,6 +89,17 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
             return event;
         }
         
+        int keyCode = (([nsEvent data1] & 0xFFFF0000) >> 16);
+        
+        if (keyCode != NX_KEYTYPE_PLAY &&
+            keyCode != NX_KEYTYPE_FAST &&
+            keyCode != NX_KEYTYPE_REWIND &&
+            keyCode != NX_KEYTYPE_PREVIOUS &&
+            keyCode != NX_KEYTYPE_NEXT)
+        {
+            return event;
+        }
+        
         iTunesApplication *iTunes = [SBApplication applicationWithBundleIdentifier:@"com.apple.iTunes"];
         SpotifyApplication *spotify = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
         
@@ -103,17 +114,6 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
             {
                 return event;
             }
-        }
-        
-        int keyCode = (([nsEvent data1] & 0xFFFF0000) >> 16);
-        
-        if (keyCode != NX_KEYTYPE_PLAY &&
-            keyCode != NX_KEYTYPE_FAST &&
-            keyCode != NX_KEYTYPE_REWIND &&
-            keyCode != NX_KEYTYPE_PREVIOUS &&
-            keyCode != NX_KEYTYPE_NEXT)
-        {
-            return event;
         }
         
         int keyFlags = ([nsEvent data1] & 0x0000FFFF);

--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -333,6 +333,7 @@ static CGEventRef tapEventCallback(CGEventTapProxy proxy, CGEventType type, CGEv
     [self updateOptionState];
     
     eventPort = CGEventTapCreate( kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, CGEventMaskBit(NX_SYSDEFINED), tapEventCallback, (__bridge void * _Nullable)(self));
+    eventPort = CGEventTapCreate( kCGSessionEventTap, kCGHeadInsertEventTap, kCGEventTapOptionDefault, NX_SYSDEFINEDMASK, tapEventCallback, (__bridge void * _Nullable)(self));
     eventPortSource = CFMachPortCreateRunLoopSource( kCFAllocatorSystemDefault, eventPort, 0 );
     
     [self startEventSession];


### PR DESCRIPTION
Today I've found this handy app and noticed it used CPU while paused. It's sad the `NX_SYSDEFINED` event captures mouse clicks.

This PR removes/adds the tap event source and stops/starts the run loop depending on manual pause status.

Also I'm mostly sure this fixes #36.